### PR TITLE
Fix for GitHub Actions and cross-platform compilation issues

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -34,12 +34,12 @@ jobs:
         working-directory: ${{github.workspace}}/build
         shell: bash
         # Execute the build.  You can specify a specific target with "--target <NAME>"
-        run: cmake --build . --config $BUILD_TYPE -j$(nproc)
+        run: cmake --build . --config $BUILD_TYPE -j$(nproc) --target expr
       - name: Upload Artifact
         uses: actions/upload-artifact@v2
         with:
           name: library
-          path: ${{ github.workspace }}/build/expr
+          path: ${{ github.workspace }}/build/libexpr.so
   build-windows:
     if: ${{ github.event.pull_request.draft == false }}
     name: Build For MS Windows Systems

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -3,10 +3,10 @@ name: CMake Pipeline
 on:
   pull_request:
     branches:
-      - master
+      - main
   push:
     branches:
-      - master
+      - main
 
 env:
   BUILD_TYPE: Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ include_directories(
         include
         src
 )
-add_library(${PROJECT_NAME}
+add_library(${PROJECT_NAME} SHARED
         ${BISON_expr_parser_OUTPUTS}
         ${FLEX_expr_scanner_OUTPUTS}
         src/parser/driver.cpp

--- a/include/operations/boolean.h
+++ b/include/operations/boolean.h
@@ -4,7 +4,8 @@
 symbol_value_t and_(const symbol_value_t& a, const symbol_value_t& b);
 symbol_value_t or_(const symbol_value_t& a, const symbol_value_t& b);
 symbol_value_t not_(const symbol_value_t& a);
-symbol_value_t operator&&(const symbol_value_t& a, const symbol_value_t& b);
-symbol_value_t operator||(const symbol_value_t& a, const symbol_value_t& b);
-symbol_value_t operator!(const symbol_value_t& a);
+// TODO: These operators are ambiguous with symbol_value_t && std::false_type / std::true_type for some reason.
+//symbol_value_t operator&&(const symbol_value_t& a, const symbol_value_t& b);
+//symbol_value_t operator||(const symbol_value_t& a, const symbol_value_t& b);
+//symbol_value_t operator!(const symbol_value_t& a);
 #endif //EXPR_BOOLEAN_H

--- a/src/operations/add.cpp
+++ b/src/operations/add.cpp
@@ -1,5 +1,5 @@
 #include "operations/add.h"
-#include "util.h"
+#include "operations/util.h"
 #include <sstream>
 
 template<typename T1, typename T2>

--- a/src/operations/add.cpp
+++ b/src/operations/add.cpp
@@ -4,7 +4,9 @@
 
 template<typename T1, typename T2>
 auto t_add(const T1&, const T2&) {
-    throw std::domain_error((std::ostringstream{} << "Unable to add type " << typeid(T1).name() << " and " << typeid(T2).name()).str());
+    std::ostringstream ss{};
+    ss << "Unable to add type " << typeid(T1).name() << " and " << typeid(T2).name();
+    throw std::domain_error(ss.str());
     return nullptr; // Must return something
 }
 template<> auto t_add(const int& x, const int& y) {

--- a/src/operations/boolean.cpp
+++ b/src/operations/boolean.cpp
@@ -1,5 +1,5 @@
 #include "operations/boolean.h"
-#include "util.h"
+#include "operations/util.h"
 #include <sstream>
 
 template<typename T1, typename T2>

--- a/src/operations/boolean.cpp
+++ b/src/operations/boolean.cpp
@@ -4,17 +4,23 @@
 
 template<typename T1, typename T2>
 auto t_and(const T1&, const T2&) {
-    throw std::domain_error((std::ostringstream{} << "Unable to AND types " << typeid(T1).name() << " and " << typeid(T2).name()).str());
+    std::ostringstream ss{};
+    ss << "Unable to AND types " << typeid(T1).name() << " and " << typeid(T2).name();
+    throw std::domain_error(ss.str());
     return nullptr; // Must return something
 }
 template<typename T1, typename T2>
 auto t_or(const T1&, const T2&) {
-    throw std::domain_error((std::ostringstream{} << "Unable to OR types " << typeid(T1).name() << " and " << typeid(T2).name()).str());
+    std::ostringstream ss{};
+    ss << "Unable to OR types " << typeid(T1).name() << " and " << typeid(T2).name();
+    throw std::domain_error(ss.str());
     return nullptr; // Must return something
 }
 template<typename T1>
 auto t_not(const T1&) {
-    throw std::domain_error((std::ostringstream{} << "Unable to NOT type " << typeid(T1).name()).str());
+    std::ostringstream ss{};
+    ss << "Unable to NOT type " << typeid(T1).name();
+    throw std::domain_error(ss.str());
     return nullptr; // Must return something
 }
 

--- a/src/operations/divide.cpp
+++ b/src/operations/divide.cpp
@@ -1,5 +1,5 @@
 #include "operations/divide.h"
-#include "util.h"
+#include "operations/util.h"
 #include <sstream>
 
 template<typename T1, typename T2>

--- a/src/operations/divide.cpp
+++ b/src/operations/divide.cpp
@@ -4,23 +4,29 @@
 
 template<typename T1, typename T2>
 auto t_divide(const T1&, const T2&) {
-    throw std::domain_error((std::ostringstream{} << "Unable to divide type " << typeid(T1).name() << " and " << typeid(T2).name()).str());
+    std::ostringstream ss{};
+    ss << "Unable to divide type " << typeid(T1).name() << " and " << typeid(T2).name();
+    throw std::domain_error(ss.str());
     return nullptr; // Must return something
 }
 template<> auto t_divide(const int& x, const int& y) {
-    if(y == 0 || (x == INT32_MIN && y == -1)) throw std::domain_error("Cannot divide with zero or INT_MIN / -1");
+    if(y == 0 || (x == INT32_MIN && y == -1))
+        throw std::domain_error("Cannot divide with zero or INT_MIN / -1");
     return x / y;
 }
 template<> auto t_divide(const float& x, const int& y) {
-    if(y == 0) throw std::domain_error("Cannot divide with zero or INT_MIN / -1");
+    if(y == 0)
+        throw std::domain_error("Cannot divide with zero or INT_MIN / -1");
     return x / y;
 }
 template<> auto t_divide(const int& x, const float& y) {
-    if(y == 0.0f) throw std::domain_error("Cannot divide with zero or INT_MIN / -1");
+    if(y == 0.0f)
+        throw std::domain_error("Cannot divide with zero or INT_MIN / -1");
     return x / y;
 }
 template<> auto t_divide(const float& x, const float& y) {
-    if(y == 0.0f) throw std::domain_error("Cannot divide with zero or INT_MIN / -1");
+    if(y == 0.0f)
+        throw std::domain_error("Cannot divide with zero or INT_MIN / -1");
     return x / y;
 }
 

--- a/src/operations/multiply.cpp
+++ b/src/operations/multiply.cpp
@@ -1,5 +1,5 @@
 #include "operations/multiply.h"
-#include "util.h"
+#include "operations/util.h"
 #include <sstream>
 
 template<typename T1, typename T2>

--- a/src/operations/multiply.cpp
+++ b/src/operations/multiply.cpp
@@ -4,7 +4,9 @@
 
 template<typename T1, typename T2>
 auto t_multiply(const T1&, const T2&) {
-    throw std::domain_error((std::ostringstream{} << "Unable to multiply type " << typeid(T1).name() << " and " << typeid(T2).name()).str());
+    std::ostringstream ss{};
+    ss << "Unable to multiply type " << typeid(T1).name() << " and " << typeid(T2).name();
+    throw std::domain_error(ss.str());
     return nullptr; // Must return something
 }
 template<> auto t_multiply(const int& x, const int& y) {

--- a/src/operations/subtract.cpp
+++ b/src/operations/subtract.cpp
@@ -1,5 +1,5 @@
 #include "operations/subtract.h"
-#include "util.h"
+#include "operations/util.h"
 #include <sstream>
 
 template<typename T1, typename T2>

--- a/src/operations/subtract.cpp
+++ b/src/operations/subtract.cpp
@@ -4,7 +4,9 @@
 
 template<typename T1, typename T2>
 auto t_subtract(const T1&, const T2&) {
-    throw std::domain_error((std::ostringstream{} << "Unable to subtract type " << typeid(T1).name() << " and " << typeid(T2).name()).str());
+    std::ostringstream ss{};
+    ss << "Unable to subtract type " << typeid(T1).name() << " and " << typeid(T2).name();
+    throw std::domain_error(ss.str());
     return nullptr; // Must return something
 }
 template<> auto t_subtract(const int& x, const int& y) {

--- a/src/parser/parser.y
+++ b/src/parser/parser.y
@@ -1,6 +1,5 @@
 %skeleton "lalr1.cc"
-%require "3.8"
-%header
+%require "3.5"
 
 %define api.token.raw
 
@@ -23,7 +22,7 @@
 
 // Enable parser tracing and detailed errors
 %define parse.trace
-%define parse.error detailed
+%define parse.error verbose
 // Enable full lookahead to avoid incorrect error information
 // See https://www.gnu.org/software/bison/manual/html_node/LAC.html for details
 %define parse.lac full
@@ -34,6 +33,7 @@
 }
 
 %define api.token.prefix {TOK_}
+%token YYEOF 0
 %token
   ASSIGN  ":="
   MINUS   "-"


### PR DESCRIPTION
## Changes
- The primary branch is named `main` and not `master` . Fixed the GitHub Actions yml
- Fix a problem where clang and msvcpp's operator<< for ostringstream is literally not to specs (See https://stackoverflow.com/questions/59473325/no-member-named-str-in-stdbasic-ostreamchar-with-gcc-and-clang-but-no-p)
- Downgrade bison file to use bison 3.5 (because CI runs on Ubuntu)
- Sidestepped cross-platform compilation issues