### PR TITLE
Feature/declarations

### DIFF
--- a/src/parser/driver.cpp
+++ b/src/parser/driver.cpp
@@ -6,8 +6,12 @@ driver::driver(const symbol_table_t& map) : trace_parsing (false), trace_scannin
 }
 
 int driver::parse(const std::string &f) {
-    if(f.empty())
+    if(f.empty()) {
+#ifdef DEFAULT_EXPRESSION_VALUE
+        result["expression_result"] = DEFAULT_EXPRESSION_VALUE;
+#endif
         return 0;
+    }
     file = f;
     location.initialize (&file);
     scan_begin();

--- a/src/parser/parser.y
+++ b/src/parser/parser.y
@@ -51,6 +51,8 @@
   NOT     "!"
   LPAREN  "("
   RPAREN  ")"
+  ACCMOD  "access_modifier"
+  TYPE    "type"
   TERM    ";"
 ;
 
@@ -66,18 +68,21 @@
 %%
 %start unit;
 unit:
-  assignments   { }
+  statements    { }
 | cmp           { drv.result["expression_result"] = $1; }
 ;
 
-assignments:
-  %empty                     {}
-| assignment                 {}
-| assignment ";" assignments {}
+statements:
+  %empty                    {}
+| statement                 {}
+| statement ";" statements  {}
 ;
 
-assignment:
-  "identifier" ":=" cmp { drv.result[$1] = $3; };
+statement:
+  "identifier" ":=" cmp                          { drv.result[$1] = $3; }
+| "type" "identifier" ":=" cmp                   { drv.result[$2] = $4; }
+| "access_modifier" "type" "identifier" ":=" cmp { drv.result[$3] = $5; }
+;
 
 %left "+" "-";
 %left "*" "/";

--- a/src/parser/scanner.l
+++ b/src/parser/scanner.l
@@ -90,7 +90,10 @@
   yy::parser::symbol_type make_BOOL(std::string s, const yy::parser::location_type& loc);
 %}
 
-id     [a-z_A-Z][a-zA-Z_.0-9]*
+%{
+ // TODO: Remove [ðđ€\(\)]
+%}
+id     [a-z_A-Z][a-zA-Z_.0-9ðđ€\(\)]*
 int    [0-9]+
 flt    [0-9]+[.][0-9]+f
 bool   [Ff]alse|[Tt]rue

--- a/src/parser/scanner.l
+++ b/src/parser/scanner.l
@@ -90,12 +90,14 @@
   yy::parser::symbol_type make_BOOL(std::string s, const yy::parser::location_type& loc);
 %}
 
-id    [a-z_A-Z][a-zA-Z_.0-9]*
-int   [0-9]+
-flt   [0-9]+[.][0-9]+f
-bool  [Ff]alse|[Tt]rue
-str   \"(\\.|[^"\\])*\"
-blank [ \t\r]
+id     [a-z_A-Z][a-zA-Z_.0-9]*
+int    [0-9]+
+flt    [0-9]+[.][0-9]+f
+bool   [Ff]alse|[Tt]rue
+str    \"(\\.|[^"\\])*\"
+blank  [ \t\r]
+accmod [Pp](ublic|rivate|rotected)
+type   int|long|float|double|string|bool|var|auto
 
 %{
   // Code run each time a pattern is matched.
@@ -128,6 +130,9 @@ blank [ \t\r]
 ")"        return yy::parser::make_RPAREN (loc);
 ":="       return yy::parser::make_ASSIGN (loc);
 ";"        return yy::parser::make_TERM   (loc);
+
+{accmod}   return yy::parser::make_ACCMOD(loc);
+{type}     return yy::parser::make_TYPE(loc);
 
 {int}      return make_NUMBER(yytext, loc);
 {flt}      return make_FLOAT(yytext, loc);


### PR DESCRIPTION
This MR adds the possibility to declare variables without setting a value. This can be useful if you want to define an environment before you modify it.

Note that access modifiers are completely ignored and only exist for compatibility purposes
 