### PR TITLE
Fix/multiple use compatibility

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,0 +1,65 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [v1.7.0](https://github.com/sillydan1/expr/releases/tag/v1.7.0) - 2022-09-11
+
+<small>[Compare with v1.6.0](https://github.com/sillydan1/expr/compare/v1.6.0...v1.7.0)</small>
+
+### Bug Fixes
+- Cleanup interpreter::evaluate function ([137fdad](https://github.com/sillydan1/expr/commit/137fdad5284563f22ff52841b8ce5b9e90a5848e) by Asger Gitz-Johansen).
+- Interpreter now does an environment lookup for all identifier references ([e3250f5](https://github.com/sillydan1/expr/commit/e3250f53716d0d3ebc24e858dadd3ba72a36dfed) by Asger Gitz-Johansen).
+- Add space between the macro and parentheses ([0a7b2a2](https://github.com/sillydan1/expr/commit/0a7b2a213d8bf2ceca25531d90707f274f87b9cf) by Asger Gitz-Johansen).
+- Add m4_define_default parser_ns for namespace overwritability ([8b896b1](https://github.com/sillydan1/expr/commit/8b896b1334840adb3c8152720c072dee4a6d4167) by Asger Gitz-Johansen).
+
+### Features
+- Add interpret_declarations and interpret_expression functions to interpreter ([2ccc3e6](https://github.com/sillydan1/expr/commit/2ccc3e69f6271009d0d28b54ea5beb1251d96e4a) by Asger Gitz-Johansen).
+
+
+## [v1.6.0](https://github.com/sillydan1/expr/releases/tag/v1.6.0) - 2022-08-23
+
+<small>[Compare with v1.5.0](https://github.com/sillydan1/expr/compare/v1.5.0...v1.6.0)</small>
+
+
+## [v1.5.0](https://github.com/sillydan1/expr/releases/tag/v1.5.0) - 2022-07-19
+
+<small>[Compare with v1.4.1](https://github.com/sillydan1/expr/compare/v1.4.1...v1.5.0)</small>
+
+
+## [v1.4.1](https://github.com/sillydan1/expr/releases/tag/v1.4.1) - 2022-07-19
+
+<small>[Compare with v1.3.2](https://github.com/sillydan1/expr/compare/v1.3.2...v1.4.1)</small>
+
+
+## [v1.3.2](https://github.com/sillydan1/expr/releases/tag/v1.3.2) - 2022-05-02
+
+<small>[Compare with v1.3.0](https://github.com/sillydan1/expr/compare/v1.3.0...v1.3.2)</small>
+
+
+## [v1.3.0](https://github.com/sillydan1/expr/releases/tag/v1.3.0) - 2022-04-07
+
+<small>[Compare with v1.2.0](https://github.com/sillydan1/expr/compare/v1.2.0...v1.3.0)</small>
+
+
+## [v1.2.0](https://github.com/sillydan1/expr/releases/tag/v1.2.0) - 2022-03-20
+
+<small>[Compare with v1.1.3](https://github.com/sillydan1/expr/compare/v1.1.3...v1.2.0)</small>
+
+
+## [v1.1.3](https://github.com/sillydan1/expr/releases/tag/v1.1.3) - 2022-03-06
+
+<small>[Compare with v1.1.2](https://github.com/sillydan1/expr/compare/v1.1.2...v1.1.3)</small>
+
+
+## [v1.1.2](https://github.com/sillydan1/expr/releases/tag/v1.1.2) - 2022-03-05
+
+<small>[Compare with v1.0.0](https://github.com/sillydan1/expr/compare/v1.0.0...v1.1.2)</small>
+
+
+## [v1.0.0](https://github.com/sillydan1/expr/releases/tag/v1.0.0) - 2022-03-05
+
+<small>[Compare with first commit](https://github.com/sillydan1/expr/compare/8337824c2e8488a3226b773b345b0d5b537c3a7a...v1.0.0)</small>
+
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ CPMAddPackage("gh:yalibs/yatimer@1.0.0")
 CPMAddPackage("gh:yalibs/yahashcombine@1.0.0")
 CPMAddPackage("gh:sillydan1/argvparse@1.2.3")
 if(ENABLE_Z3)
-    CPMAddPackage("gh:Z3Prover/z3#z3-4.8.17")
+    CPMAddPackage("gh:Z3Prover/z3#z3-4.11.0")
 endif()
 
 set(${PROJECT_NAME}_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR} CACHE STRING "expr_BUILD_DIR" FORCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 cmake_minimum_required(VERSION 3.21)
-project(expr VERSION 1.6.0)
+project(expr VERSION 1.7.0)
 include(cmake/CPM.cmake)
 configure_file(src/config.h.in config.h)
 set(CMAKE_CXX_STANDARD 20)

--- a/include/drivers/interpreter.h
+++ b/include/drivers/interpreter.h
@@ -32,6 +32,8 @@ namespace expr {
         ~interpreter() override = default;
 
         auto parse(const std::string &f) -> int override;
+        auto interpret_declarations(const std::string& f) -> symbol_table_t;
+        auto interpret_expression(const std::string& f) -> symbol_value_t;
         auto get_symbol(const std::string& identifier) -> syntax_tree_t override;
         void add_tree(const syntax_tree_t& tree) override;
         void add_tree(const std::string& identifier, const syntax_tree_t& tree) override;

--- a/include/drivers/interpreter.h
+++ b/include/drivers/interpreter.h
@@ -38,33 +38,33 @@ namespace expr {
         void add_tree(const syntax_tree_t& tree) override;
         void add_tree(const std::string& identifier, const syntax_tree_t& tree) override;
 
-        auto add(const symbol_value_t &a, const symbol_value_t &b) -> symbol_value_t override { return ::operator+(a,b); };
-        auto sub(const symbol_value_t &a, const symbol_value_t &b) -> symbol_value_t override { return a - b; };
-        auto mul(const symbol_value_t &a, const symbol_value_t &b) -> symbol_value_t override { return a * b; };
-        auto div(const symbol_value_t &a, const symbol_value_t &b) -> symbol_value_t override { return a / b; };
-        auto mod(const symbol_value_t &a, const symbol_value_t &b) -> symbol_value_t override { return a % b; };
-        auto pow(const symbol_value_t &a, const symbol_value_t &b) -> symbol_value_t override { return a ^ b; };
+        auto add(const symbol_value_t &a, const symbol_value_t &b) const -> symbol_value_t override { return ::operator+(a,b); };
+        auto sub(const symbol_value_t &a, const symbol_value_t &b) const -> symbol_value_t override { return a - b; };
+        auto mul(const symbol_value_t &a, const symbol_value_t &b) const -> symbol_value_t override { return a * b; };
+        auto div(const symbol_value_t &a, const symbol_value_t &b) const -> symbol_value_t override { return a / b; };
+        auto mod(const symbol_value_t &a, const symbol_value_t &b) const -> symbol_value_t override { return a % b; };
+        auto pow(const symbol_value_t &a, const symbol_value_t &b) const -> symbol_value_t override { return a ^ b; };
 
-        auto _not(const symbol_value_t &a) -> symbol_value_t override { return not_(a); }
-        auto _and(const symbol_value_t &a, const symbol_value_t &b) -> symbol_value_t override { return and_(a,b); }
-        auto _or(const symbol_value_t &a, const symbol_value_t &b) -> symbol_value_t override { return or_(a,b); }
-        auto _xor(const symbol_value_t &a, const symbol_value_t &b) -> symbol_value_t override { return xor_(a,b); }
-        auto _implies(const symbol_value_t &a, const symbol_value_t &b) -> symbol_value_t override { return implies_(a,b); }
+        auto _not(const symbol_value_t &a) const -> symbol_value_t override { return not_(a); }
+        auto _and(const symbol_value_t &a, const symbol_value_t &b) const -> symbol_value_t override { return and_(a,b); }
+        auto _or(const symbol_value_t &a, const symbol_value_t &b) const -> symbol_value_t override { return or_(a,b); }
+        auto _xor(const symbol_value_t &a, const symbol_value_t &b) const -> symbol_value_t override { return xor_(a,b); }
+        auto _implies(const symbol_value_t &a, const symbol_value_t &b) const -> symbol_value_t override { return implies_(a,b); }
 
-        auto gt(const symbol_value_t &a, const symbol_value_t &b) -> symbol_value_t override { return gt_(a,b); }
-        auto ge(const symbol_value_t &a, const symbol_value_t &b) -> symbol_value_t override { return ge_(a,b); }
-        auto ee(const symbol_value_t &a, const symbol_value_t &b) -> symbol_value_t override { return ee_(a,b); }
-        auto ne(const symbol_value_t &a, const symbol_value_t &b) -> symbol_value_t override { return ne_(a,b); }
-        auto le(const symbol_value_t &a, const symbol_value_t &b) -> symbol_value_t override { return le_(a,b); }
-        auto lt(const symbol_value_t &a, const symbol_value_t &b) -> symbol_value_t override { return lt_(a,b); }
+        auto gt(const symbol_value_t &a, const symbol_value_t &b) const -> symbol_value_t override { return gt_(a,b); }
+        auto ge(const symbol_value_t &a, const symbol_value_t &b) const -> symbol_value_t override { return ge_(a,b); }
+        auto ee(const symbol_value_t &a, const symbol_value_t &b) const -> symbol_value_t override { return ee_(a,b); }
+        auto ne(const symbol_value_t &a, const symbol_value_t &b) const -> symbol_value_t override { return ne_(a,b); }
+        auto le(const symbol_value_t &a, const symbol_value_t &b) const -> symbol_value_t override { return le_(a,b); }
+        auto lt(const symbol_value_t &a, const symbol_value_t &b) const -> symbol_value_t override { return lt_(a,b); }
 
         symbol_table_t result{};
         symbol_value_t expression_result{};
 
         auto evaluate(const syntax_tree_t& tree) -> symbol_value_t;
         auto evaluate(const compiler::compiled_expr_collection_t& tree) -> symbol_table_t;
-        static auto evaluate(const syntax_tree_t& tree, expr::arithmetic_operator& arith, expr::boolean_operator& boolean, expr::compare_operator& comparator, const symbol_table_t& symbols) -> symbol_value_t;
-        static auto evaluate(const compiler::compiled_expr_collection_t& symbol_tree_map, expr::arithmetic_operator& arith, expr::boolean_operator& boolean, expr::compare_operator& comparator, const symbol_table_t& symbols) -> symbol_table_t;
+        static auto evaluate(const syntax_tree_t& tree, const interpreter& op, const symbol_table_t& symbols) -> symbol_value_t;
+        static auto evaluate(const compiler::compiled_expr_collection_t& symbol_tree_map, const interpreter& op, const symbol_table_t& symbols) -> symbol_table_t;
 
     protected:
         const symbol_table_t &environment{};

--- a/include/drivers/interpreter.h
+++ b/include/drivers/interpreter.h
@@ -59,8 +59,10 @@ namespace expr {
         symbol_table_t result{};
         symbol_value_t expression_result{};
 
-        static auto evaluate(const syntax_tree_t& tree, expr::arithmetic_operator& arith, expr::boolean_operator& boolean, expr::compare_operator& comparator) -> symbol_value_t;
-        static auto evaluate(const compiler::compiled_expr_collection_t& symbol_tree_map, expr::arithmetic_operator& arith, expr::boolean_operator& boolean, expr::compare_operator& comparator) -> symbol_table_t;
+        auto evaluate(const syntax_tree_t& tree) -> symbol_value_t;
+        auto evaluate(const compiler::compiled_expr_collection_t& tree) -> symbol_table_t;
+        static auto evaluate(const syntax_tree_t& tree, expr::arithmetic_operator& arith, expr::boolean_operator& boolean, expr::compare_operator& comparator, const symbol_table_t& symbols) -> symbol_value_t;
+        static auto evaluate(const compiler::compiled_expr_collection_t& symbol_tree_map, expr::arithmetic_operator& arith, expr::boolean_operator& boolean, expr::compare_operator& comparator, const symbol_table_t& symbols) -> symbol_table_t;
 
     protected:
         const symbol_table_t &environment{};

--- a/src/drivers/interpreter.cpp
+++ b/src/drivers/interpreter.cpp
@@ -50,6 +50,22 @@ namespace expr {
         }
     }
 
+    auto interpreter::interpret_declarations(const std::string &f) -> symbol_table_t {
+        result = {};
+        auto res = parse(f);
+        if(res != 0)
+            throw std::logic_error(error);
+        return result;
+    }
+
+    auto interpreter::interpret_expression(const std::string &f) -> symbol_value_t {
+        expression_result = {};
+        auto res = parse(f);
+        if(res != 0)
+            throw std::logic_error(error);
+        return expression_result;
+    }
+
     auto interpreter::get_symbol(const std::string &identifier) -> syntax_tree_t {
 #ifndef NDEBUG
         if (!environment.contains(identifier))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -117,8 +117,7 @@ int main (int argc, char *argv[]) {
                 std::cout << tree.first << ": " << tree.second << "\n";
             std::cout << "\n";
             interpreter i{drv_c->get_environment()};
-            auto eval = [&i](const compiler::compiled_expr_collection_t& t){return interpreter::evaluate(t,i,i,i);};
-            std::cout << eval(drv_c->trees) << "\n";
+            std::cout << i.evaluate(drv_c->trees) << "\n";
         }
         if(cli_arguments["driver"].as_string() == "interpreter") {
             auto drv_i = std::dynamic_pointer_cast<interpreter>(drv);

--- a/src/operations.h
+++ b/src/operations.h
@@ -32,27 +32,27 @@
 
 namespace expr {
     struct arithmetic_operator {
-        virtual auto add(const symbol_value_t &a, const symbol_value_t &b) -> symbol_value_t = 0;
-        virtual auto sub(const symbol_value_t &a, const symbol_value_t &b) -> symbol_value_t = 0;
-        virtual auto mul(const symbol_value_t &a, const symbol_value_t &b) -> symbol_value_t = 0;
-        virtual auto div(const symbol_value_t &a, const symbol_value_t &b) -> symbol_value_t = 0;
-        virtual auto mod(const symbol_value_t &a, const symbol_value_t &b) -> symbol_value_t = 0;
-        virtual auto pow(const symbol_value_t &a, const symbol_value_t &b) -> symbol_value_t = 0;
+        virtual auto add(const symbol_value_t &a, const symbol_value_t &b) const -> symbol_value_t = 0;
+        virtual auto sub(const symbol_value_t &a, const symbol_value_t &b) const -> symbol_value_t = 0;
+        virtual auto mul(const symbol_value_t &a, const symbol_value_t &b) const -> symbol_value_t = 0;
+        virtual auto div(const symbol_value_t &a, const symbol_value_t &b) const -> symbol_value_t = 0;
+        virtual auto mod(const symbol_value_t &a, const symbol_value_t &b) const -> symbol_value_t = 0;
+        virtual auto pow(const symbol_value_t &a, const symbol_value_t &b) const -> symbol_value_t = 0;
     };
     struct boolean_operator {
-        virtual auto _not(const symbol_value_t &a) -> symbol_value_t = 0;
-        virtual auto _and(const symbol_value_t &a, const symbol_value_t &b) -> symbol_value_t = 0;
-        virtual auto _or(const symbol_value_t &a, const symbol_value_t &b) -> symbol_value_t = 0;
-        virtual auto _xor(const symbol_value_t &a, const symbol_value_t &b) -> symbol_value_t = 0;
-        virtual auto _implies(const symbol_value_t& a, const symbol_value_t& b) -> symbol_value_t = 0;
+        virtual auto _not(const symbol_value_t &a) const -> symbol_value_t = 0;
+        virtual auto _and(const symbol_value_t &a, const symbol_value_t &b) const -> symbol_value_t = 0;
+        virtual auto _or(const symbol_value_t &a, const symbol_value_t &b) const -> symbol_value_t = 0;
+        virtual auto _xor(const symbol_value_t &a, const symbol_value_t &b) const -> symbol_value_t = 0;
+        virtual auto _implies(const symbol_value_t& a, const symbol_value_t& b) const -> symbol_value_t = 0;
     };
     struct compare_operator {
-        virtual auto gt(const symbol_value_t &a, const symbol_value_t &b) -> symbol_value_t = 0;
-        virtual auto ge(const symbol_value_t &a, const symbol_value_t &b) -> symbol_value_t = 0;
-        virtual auto ee(const symbol_value_t &a, const symbol_value_t &b) -> symbol_value_t = 0;
-        virtual auto ne(const symbol_value_t &a, const symbol_value_t &b) -> symbol_value_t = 0;
-        virtual auto le(const symbol_value_t &a, const symbol_value_t &b) -> symbol_value_t = 0;
-        virtual auto lt(const symbol_value_t &a, const symbol_value_t &b) -> symbol_value_t = 0;
+        virtual auto gt(const symbol_value_t &a, const symbol_value_t &b) const -> symbol_value_t = 0;
+        virtual auto ge(const symbol_value_t &a, const symbol_value_t &b) const -> symbol_value_t = 0;
+        virtual auto ee(const symbol_value_t &a, const symbol_value_t &b) const -> symbol_value_t = 0;
+        virtual auto ne(const symbol_value_t &a, const symbol_value_t &b) const -> symbol_value_t = 0;
+        virtual auto le(const symbol_value_t &a, const symbol_value_t &b) const -> symbol_value_t = 0;
+        virtual auto lt(const symbol_value_t &a, const symbol_value_t &b) const -> symbol_value_t = 0;
     };
 }
 

--- a/src/parser/lex/footer.l
+++ b/src/parser/lex/footer.l
@@ -1,29 +1,29 @@
 m4_changequote()
 
-yy::parser::symbol_type make_NUMBER(const std::string &s, const yy::parser::location_type& loc) {
+PARSER_NS ::parser::symbol_type make_NUMBER(const std::string &s, const PARSER_NS ::parser::location_type& loc) {
   errno = 0;
   long n = strtol (s.c_str(), NULL, 10);
   if (! (INT_MIN <= n && n <= INT_MAX && errno != ERANGE))
-    throw yy::parser::syntax_error (loc, "integer is out of range: " + s);
-  return yy::parser::make_NUMBER ((int) n, loc);
+    throw PARSER_NS ::parser::syntax_error (loc, "integer is out of range: " + s);
+  return PARSER_NS ::parser::make_NUMBER ((int) n, loc);
 }
 
-yy::parser::symbol_type make_FLOAT(const std::string &s, const yy::parser::location_type& loc) {
+PARSER_NS ::parser::symbol_type make_FLOAT(const std::string &s, const PARSER_NS ::parser::location_type& loc) {
     try {
         double n = std::stod(s.c_str());
-        return yy::parser::make_FLOAT((double)n, loc);
+        return PARSER_NS ::parser::make_FLOAT((double)n, loc);
     } catch(std::out_of_range& e) {
-        throw yy::parser::syntax_error (loc, "double is out of range: " + s);
+        throw PARSER_NS ::parser::syntax_error (loc, "double is out of range: " + s);
     }
 }
 
-yy::parser::symbol_type make_STRING(const std::string &s, const yy::parser::location_type& loc) {
-    return yy::parser::make_STRING(s.substr(1, s.size()-2), loc);
+PARSER_NS ::parser::symbol_type make_STRING(const std::string &s, const PARSER_NS ::parser::location_type& loc) {
+    return PARSER_NS ::parser::make_STRING(s.substr(1, s.size()-2), loc);
 }
 
-yy::parser::symbol_type make_BOOL(std::string s, const yy::parser::location_type& loc) {
+PARSER_NS ::parser::symbol_type make_BOOL(std::string s, const PARSER_NS ::parser::location_type& loc) {
     std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c){ return std::tolower(c); });
     bool b;
     std::istringstream(s) >> std::boolalpha >> b;
-    return yy::parser::make_BOOL(b, loc);
+    return PARSER_NS ::parser::make_BOOL(b, loc);
 }

--- a/src/parser/lex/lexer.l
+++ b/src/parser/lex/lexer.l
@@ -3,35 +3,35 @@ m4_changequote()
 {blank}+   loc.step();
 \n+        { loc.lines(yyleng); loc.step(); }
 
-"-"        return yy::parser::make_MINUS  (loc);
-"+"        return yy::parser::make_PLUS   (loc);
-"*"        return yy::parser::make_STAR   (loc);
-"/"        return yy::parser::make_SLASH  (loc);
-"%"        return yy::parser::make_PERCENT(loc);
-"^"        return yy::parser::make_HAT    (loc);
-"&&"       return yy::parser::make_AND    (loc);
-"||"       return yy::parser::make_OR     (loc);
-"^^"       return yy::parser::make_XOR    (loc);
-"=>"       return yy::parser::make_IMPLIES(loc);
-">"        return yy::parser::make_GT     (loc);
-">="       return yy::parser::make_GE     (loc);
-"=="       return yy::parser::make_EE     (loc);
-"!="       return yy::parser::make_NE     (loc);
-"<="       return yy::parser::make_LE     (loc);
-"<"        return yy::parser::make_LT     (loc);
-"!"        return yy::parser::make_NOT    (loc);
-"("        return yy::parser::make_LPAREN (loc);
-")"        return yy::parser::make_RPAREN (loc);
-":="       return yy::parser::make_ASSIGN (loc);
-";"        return yy::parser::make_TERM   (loc);
+"-"        return PARSER_NS ::parser::make_MINUS  (loc);
+"+"        return PARSER_NS ::parser::make_PLUS   (loc);
+"*"        return PARSER_NS ::parser::make_STAR   (loc);
+"/"        return PARSER_NS ::parser::make_SLASH  (loc);
+"%"        return PARSER_NS ::parser::make_PERCENT(loc);
+"^"        return PARSER_NS ::parser::make_HAT    (loc);
+"&&"       return PARSER_NS ::parser::make_AND    (loc);
+"||"       return PARSER_NS ::parser::make_OR     (loc);
+"^^"       return PARSER_NS ::parser::make_XOR    (loc);
+"=>"       return PARSER_NS ::parser::make_IMPLIES(loc);
+">"        return PARSER_NS ::parser::make_GT     (loc);
+">="       return PARSER_NS ::parser::make_GE     (loc);
+"=="       return PARSER_NS ::parser::make_EE     (loc);
+"!="       return PARSER_NS ::parser::make_NE     (loc);
+"<="       return PARSER_NS ::parser::make_LE     (loc);
+"<"        return PARSER_NS ::parser::make_LT     (loc);
+"!"        return PARSER_NS ::parser::make_NOT    (loc);
+"("        return PARSER_NS ::parser::make_LPAREN (loc);
+")"        return PARSER_NS ::parser::make_RPAREN (loc);
+":="       return PARSER_NS ::parser::make_ASSIGN (loc);
+";"        return PARSER_NS ::parser::make_TERM   (loc);
 
-{accmod}   return yy::parser::make_ACCMOD(loc);
-{type}     return yy::parser::make_TYPE(loc);
+{accmod}   return PARSER_NS ::parser::make_ACCMOD(loc);
+{type}     return PARSER_NS ::parser::make_TYPE(loc);
 
 {int}      return make_NUMBER(yytext, loc);
 {flt}      return make_FLOAT(yytext, loc);
 {str}      return make_STRING(yytext, loc);
 {bool}     return make_BOOL(yytext, loc);
-{id}       return yy::parser::make_IDENTIFIER (yytext, loc);
-.          { throw yy::parser::syntax_error(loc, "invalid character: " + std::string(yytext)); }
-<<EOF>>    return yy::parser::make_YYEOF (loc);
+{id}       return PARSER_NS ::parser::make_IDENTIFIER (yytext, loc);
+.          { throw PARSER_NS ::parser::syntax_error(loc, "invalid character: " + std::string(yytext)); }
+<<EOF>>    return PARSER_NS ::parser::make_YYEOF (loc);

--- a/src/parser/lex/scanner.l
+++ b/src/parser/lex/scanner.l
@@ -2,7 +2,7 @@ m4_changequote()
 /*
 m4_include(../mit.license)
 */
-
+m4_define(PARSER_NS, yy)
 m4_include(includes.l)
 m4_include(skeleton.l)
 m4_include(tokens.l)

--- a/src/parser/lex/skeleton.l
+++ b/src/parser/lex/skeleton.l
@@ -75,8 +75,8 @@ m4_changequote()
 
 %{
   // A number symbol corresponding to the value in provided string.
-  yy::parser::symbol_type make_NUMBER(const std::string &s, const yy::parser::location_type& loc);
-  yy::parser::symbol_type make_FLOAT(const std::string &s, const yy::parser::location_type& loc);
-  yy::parser::symbol_type make_STRING(const std::string &s, const yy::parser::location_type& loc);
-  yy::parser::symbol_type make_BOOL(std::string s, const yy::parser::location_type& loc);
+  PARSER_NS ::parser::symbol_type make_NUMBER(const std::string &s, const PARSER_NS ::parser::location_type& loc);
+  PARSER_NS ::parser::symbol_type make_FLOAT(const std::string &s, const PARSER_NS ::parser::location_type& loc);
+  PARSER_NS ::parser::symbol_type make_STRING(const std::string &s, const PARSER_NS ::parser::location_type& loc);
+  PARSER_NS ::parser::symbol_type make_BOOL(std::string s, const PARSER_NS ::parser::location_type& loc);
 %}

--- a/src/parser/yacc/exp.y
+++ b/src/parser/yacc/exp.y
@@ -7,35 +7,35 @@ exp:
 ;
 
 bin_op:
-  exp PLUS exp          { $$ = BINOP_CTOR(plus,$1,$3);     }
-| exp MINUS exp         { $$ = BINOP_CTOR(minus,$1,$3);    }
-| exp STAR exp          { $$ = BINOP_CTOR(star,$1,$3);     }
-| exp SLASH exp         { $$ = BINOP_CTOR(slash,$1,$3);    }
-| exp PERCENT exp       { $$ = BINOP_CTOR(percent,$1,$3);  }
-| exp HAT exp           { $$ = BINOP_CTOR(hat,$1,$3);      }
-| exp GT  exp           { $$ = BINOP_CTOR(gt,$1,$3);       }
-| exp GE exp            { $$ = BINOP_CTOR(ge,$1,$3);       }
-| exp EE exp            { $$ = BINOP_CTOR(ee,$1,$3);       }
-| exp NE exp            { $$ = BINOP_CTOR(ne,$1,$3);       }
-| exp LE exp            { $$ = BINOP_CTOR(le,$1,$3);       }
-| exp LT  exp           { $$ = BINOP_CTOR(lt,$1,$3);       }
-| exp OR exp            { $$ = BINOP_CTOR(_or,$1,$3);      }
-| exp XOR exp           { $$ = BINOP_CTOR(_xor,$1,$3);     }
-| exp IMPLIES exp       { $$ = BINOP_CTOR(_implies,$1,$3); }
-| exp AND exp           { $$ = BINOP_CTOR(_and,$1,$3);     }
+  exp PLUS exp          { $$ = BINOP_CTOR (plus,$1,$3);     }
+| exp MINUS exp         { $$ = BINOP_CTOR (minus,$1,$3);    }
+| exp STAR exp          { $$ = BINOP_CTOR (star,$1,$3);     }
+| exp SLASH exp         { $$ = BINOP_CTOR (slash,$1,$3);    }
+| exp PERCENT exp       { $$ = BINOP_CTOR (percent,$1,$3);  }
+| exp HAT exp           { $$ = BINOP_CTOR (hat,$1,$3);      }
+| exp GT  exp           { $$ = BINOP_CTOR (gt,$1,$3);       }
+| exp GE exp            { $$ = BINOP_CTOR (ge,$1,$3);       }
+| exp EE exp            { $$ = BINOP_CTOR (ee,$1,$3);       }
+| exp NE exp            { $$ = BINOP_CTOR (ne,$1,$3);       }
+| exp LE exp            { $$ = BINOP_CTOR (le,$1,$3);       }
+| exp LT  exp           { $$ = BINOP_CTOR (lt,$1,$3);       }
+| exp OR exp            { $$ = BINOP_CTOR (_or,$1,$3);      }
+| exp XOR exp           { $$ = BINOP_CTOR (_xor,$1,$3);     }
+| exp IMPLIES exp       { $$ = BINOP_CTOR (_implies,$1,$3); }
+| exp AND exp           { $$ = BINOP_CTOR (_and,$1,$3);     }
 ;
 
 mono_op:
-  NOT exp               { $$ = MONOOP_CTOR(_not,$2);        }
-| LPAREN exp RPAREN     { $$ = MONOOP_CTOR(parentheses,$2); }
+  NOT exp               { $$ = MONOOP_CTOR (_not,$2);        }
+| LPAREN exp RPAREN     { $$ = MONOOP_CTOR (parentheses,$2); }
 ;
 
 lit:
-  "number"              { $$ = LIT_CTOR($1);   }
-| MINUS "number"        { $$ = LIT_CTOR(-$2);  }
-| "float"               { $$ = LIT_CTOR($1);   }
-| MINUS "float"         { $$ = LIT_CTOR(-$2);  }
-| "string"              { $$ = LIT_CTOR($1);   }
-| "bool"                { $$ = LIT_CTOR($1);   }
-| "identifier"          { $$ = IDENT_CTOR($1); }
+  "number"              { $$ = LIT_CTOR ($1);   }
+| MINUS "number"        { $$ = LIT_CTOR (-$2);  }
+| "float"               { $$ = LIT_CTOR ($1);   }
+| MINUS "float"         { $$ = LIT_CTOR (-$2);  }
+| "string"              { $$ = LIT_CTOR ($1);   }
+| "bool"                { $$ = LIT_CTOR ($1);   }
+| "identifier"          { $$ = IDENT_CTOR ($1); }
 ;

--- a/src/parser/yacc/parser.y
+++ b/src/parser/yacc/parser.y
@@ -2,7 +2,9 @@ m4_changequote()
 /*
 m4_include(../mit.license)
 */
+m4_define(PARSER_NS, yy)
 m4_include(skeleton.y)
+%define api.prefix {PARSER_NS}
 m4_include(tokens.y)
 m4_include(token_types.y)
 

--- a/src/parser/yacc/skeleton.y
+++ b/src/parser/yacc/skeleton.y
@@ -31,7 +31,7 @@ m4_changequote()
 // Include the driver
 %code {
     #include "drivers/driver.h"
-    void yy::parser::error (const location_type& l, const std::string& m) {
+    void PARSER_NS ::parser::error (const location_type& l, const std::string& m) {
       std::cerr << l << ": " << m << '\n';
     }
 }


### PR DESCRIPTION
<small>[Compare with v1.6.0](https://github.com/sillydan1/expr/compare/v1.6.0...v1.7.0)</small>
## v1.7.0

### Bug Fixes
- Cleanup interpreter::evaluate function ([137fdad](https://github.com/sillydan1/expr/commit/137fdad5284563f22ff52841b8ce5b9e90a5848e) by Asger Gitz-Johansen).
- Interpreter now does an environment lookup for all identifier references ([e3250f5](https://github.com/sillydan1/expr/commit/e3250f53716d0d3ebc24e858dadd3ba72a36dfed) by Asger Gitz-Johansen).
- Add space between the macro and parentheses ([0a7b2a2](https://github.com/sillydan1/expr/commit/0a7b2a213d8bf2ceca25531d90707f274f87b9cf) by Asger Gitz-Johansen).
- Add m4_define_default parser_ns for namespace overwritability ([8b896b1](https://github.com/sillydan1/expr/commit/8b896b1334840adb3c8152720c072dee4a6d4167) by Asger Gitz-Johansen).

### Features
- Add interpret_declarations and interpret_expression functions to interpreter ([2ccc3e6](https://github.com/sillydan1/expr/commit/2ccc3e69f6271009d0d28b54ea5beb1251d96e4a) by Asger Gitz-Johansen).
